### PR TITLE
fix #6 when build-decision fails, build continues

### DIFF
--- a/docs/designer-decisions/scripts/build-decisions.mjs
+++ b/docs/designer-decisions/scripts/build-decisions.mjs
@@ -1,37 +1,34 @@
+import {
+    formatStoreError,
+    formatValidationError,
+    createDecisionLoader,
+} from '@noodlestan/designer-functions';
 import path from 'path';
 
 import { SAMPLE_DATA } from '@noodlestan/designer-decisions';
-import {
-    createDecisionLoader,
-    formatDecision,
-    formatValidationError,
-    getDecisionStatus,
-} from '@noodlestan/designer-functions';
 import { DECISION_SCHEMAS } from '@noodlestan/designer-schemas';
 
 const DATA_PATH = path.resolve('./data/decisions');
 
-const loader = createDecisionLoader(
+const decisionLoader = createDecisionLoader(
     [DECISION_SCHEMAS],
     [SAMPLE_DATA, DATA_PATH],
     async moduleName => `../../node_modules/${moduleName}`,
 );
 
-const loadDecisions = async () => {
-    const store = await loader();
+const load = async () => {
+    const store = await decisionLoader();
     if (store.hasErrors()) {
-        store.storeErrors().forEach(({ msg, error }) => console.error(msg, error));
-        store.validationErrors().forEach(error => console.error(formatValidationError(error)));
+        store.storeErrors()?.forEach(error => console.error(formatStoreError(error)));
+        store.validationErrors()?.forEach(error => console.error(formatValidationError(error)));
     }
-    const records = store.records();
+    const records = store.records().length;
     const errors = store.storeErrors().length;
     const validationErrors = store.validationErrors().length;
-    console.info(`🐘 ${records.length} records, ${errors} errors, ${validationErrors} warnings`);
-
-    records.forEach(record => {
-        const status = getDecisionStatus(store, record);
-        console.info(formatDecision(status));
-    });
+    console.info(`🐘 ${records} records, ${errors} errors, ${validationErrors} warnings`);
+    if (store.hasErrors()) {
+        throw new Error();
+    }
 };
 
-loadDecisions();
+load().catch(() => process.exit(1));


### PR DESCRIPTION
Fixes https://github.com/noodlestan/designer/issues/6

## Fix 

Changed the local `build-decisions.mjs` in our docs to to just that ☝ 

```
const load = async () => {
    const store = await decisionLoader();
    ....
    if (store.hasErrors()) {
        throw new Error();
    }
};

load().catch(() => process.exit(1));
```

Whit this change: 

- `run run dev` never crashes (but all decisions become unavailable) 
- `npm run build` stops after `npm run build:decisions` fails


<img width="780" alt="Image" src="https://github.com/user-attachments/assets/8492dba0-1636-42be-a95a-e4b237d1514b" />


<img width="857" alt="Image" src="https://github.com/user-attachments/assets/5fb2b0ad-e125-4ebe-a812-f796781315c0" />
