### PR TITLE
Add layout prop to DecisionCard 

### DIFF
--- a/docs/designer-decisions/src/content/docs/components/Astro/ShowDecision.mdx
+++ b/docs/designer-decisions/src/content/docs/components/Astro/ShowDecision.mdx
@@ -40,7 +40,7 @@ Refer to the table on [Composable Types](/components/Astro/Composable/Types) to 
 
 These two **mandatory** `store` and `d` props serve to identify and retrieve the decision.
 
-The optional `layout` prop controls the flow of multiple items and the value/viz pair.
+The optional `layout` prop controls the flow of items in set/scale decisions and the relative position of the value/viz pair.
 
 ### ༶ [ValueProps](/components/Astro/Props#valueprops): `value`
 

--- a/docs/designer-decisions/src/content/docs/components/Astro/ShowDecisionCard.mdx
+++ b/docs/designer-decisions/src/content/docs/components/Astro/ShowDecisionCard.mdx
@@ -33,11 +33,26 @@ This component composes:
 
 ## Props
 
-### ༶ [DecisionProps](/components/Astro/Props): `store`, `d` and `layout`
+### ༶ [DecisionProps](/components/Astro/Props): `store` and `d`
 
 These two **mandatory** `store` and `d` props serve to identify and retrieve the decision.
 
-The optional `layout` prop controls the flow of multiple items and the value/viz pair.
+### ༶ [DecisionProps](/components/Astro/Props): `layout`
+
+The optional `layout` prop controls the flow of items in set/scale decisions and the relative position of the value/viz pair.
+
+The layout of the card adapts automatically to the layout of set/scale decisions in order to use the available space:
+
+-   `row` - card uses `column` layout, rendering visualization first, then values.
+-   `column` - card uses `row` layout, rendering visualization and details side by side.
+
+```mdx
+<ShowDecisionCard store={store} d="Pink Palette" value={false} size="m" />
+```
+
+<ShowDecisionCard store={store} d="Pink Palette" value={false} size="m" />
+
+The layout of the card is otherwise unaffected by the layout prop if the decision produces a single value.
 
 ### ༶ [ValueProps](/components/Astro/Props#valueprops): `value`
 

--- a/docs/designer-decisions/src/content/docs/components/Astro/index.mdx
+++ b/docs/designer-decisions/src/content/docs/components/Astro/index.mdx
@@ -22,7 +22,7 @@ import { href } from '../../../../mdx';
 All components that render a decision, such as the [ShowDecisionCard](components/Astro/ShowDecisionCard/) component, share the same common props:
 
 -   `d` and `store`: to identify and retrieve the decision.
--   `layout`: to control the flow of multiple items and the value/viz pair.
+-   `layout`: to control the flow of items in set/scale decisions and the relative position of the value/viz pair.
 -   `value`, `viz`, `size`, and `options`: to control how the visualization and value are displayed.
 
 Refer to [Common Props](/components/Astro/Props) for more details on these props.

--- a/packages/libs/designer-shows/src/astro/attributes/ShowDecisionData.astro
+++ b/packages/libs/designer-shows/src/astro/attributes/ShowDecisionData.astro
@@ -1,9 +1,9 @@
 ---
-import { type ShowDataProps } from '../types';
+import { type ShowDecisionProps } from '../types';
 
 import { Code } from 'astro-expressive-code/components';
 
-type Props = ShowDataProps;
+type Props = ShowDecisionProps;
 
 const { store, d } = Astro.props;
 

--- a/packages/libs/designer-shows/src/astro/attributes/ShowDecisionDescription.astro
+++ b/packages/libs/designer-shows/src/astro/attributes/ShowDecisionDescription.astro
@@ -1,7 +1,7 @@
 ---
-import { type ShowDataProps } from '../types';
+import { type ShowDecisionProps } from '../types';
 
-type Props = ShowDataProps;
+type Props = ShowDecisionProps;
 
 const { store, d } = Astro.props;
 

--- a/packages/libs/designer-shows/src/astro/attributes/ShowDecisionModel.astro
+++ b/packages/libs/designer-shows/src/astro/attributes/ShowDecisionModel.astro
@@ -1,7 +1,7 @@
 ---
-import { type ShowDataProps } from '../types';
+import { type ShowDecisionProps } from '../types';
 
-type Props = ShowDataProps;
+type Props = ShowDecisionProps;
 
 const { store, d } = Astro.props;
 

--- a/packages/libs/designer-shows/src/astro/attributes/ShowDecisionParams.astro
+++ b/packages/libs/designer-shows/src/astro/attributes/ShowDecisionParams.astro
@@ -1,7 +1,7 @@
 ---
-import { type ShowDataProps } from '../types';
+import { type ShowDecisionProps } from '../types';
 
-type Props = ShowDataProps;
+type Props = ShowDecisionProps;
 
 const { store, d } = Astro.props;
 

--- a/packages/libs/designer-shows/src/astro/attributes/ShowDecisionUsage.astro
+++ b/packages/libs/designer-shows/src/astro/attributes/ShowDecisionUsage.astro
@@ -1,8 +1,8 @@
 ---
-import { type ShowDataProps } from '../types';
+import { type ShowDecisionProps } from '../types';
 import { LayoutFlex } from '../layouts';
 
-type Props = ShowDataProps;
+type Props = ShowDecisionProps;
 
 const { store, d } = Astro.props;
 
@@ -15,7 +15,7 @@ const { intendedFor = [], notFor = [] } = decision?.inputs()[0].usage || {}; // 
         intendedFor.length > 0 && (
             <LayoutFlex wrap={false}>
                 <h4 class="dd-group-header">Intended For:</h4>
-                <LayoutFlex tag="ul">
+                <LayoutFlex tag="ul" gap="s">
                     {intendedFor.map(item => (
                         <li class="dd-item">{item}</li>
                     ))}
@@ -27,7 +27,7 @@ const { intendedFor = [], notFor = [] } = decision?.inputs()[0].usage || {}; // 
         notFor.length > 0 && (
             <LayoutFlex>
                 <h4 class="dd-group-header">Not For:</h4>
-                <LayoutFlex tag="ul">
+                <LayoutFlex tag="ul" gap="s">
                     {notFor.map(item => (
                         <li class="dd-item">{item}</li>
                     ))}

--- a/packages/libs/designer-shows/src/astro/cards/ShowDecisionCard.astro
+++ b/packages/libs/designer-shows/src/astro/cards/ShowDecisionCard.astro
@@ -1,7 +1,9 @@
 ---
-import { type ShowDecisionProps } from '../types';
+import { isSetDecision } from '@noodlestan/designer-decisions';
+
+import { type DecisionTypeComponentProps, type ShowDecisionLayout } from '../types';
 import { ShowDecision } from '../decisions';
-import { DecisionCardLayout } from '../layouts';
+import { DecisionCardLayout, type LayoutDynamicProps } from '../layouts';
 import {
     ShowDecisionContexts,
     ShowDecisionData,
@@ -10,8 +12,9 @@ import {
     ShowDecisionParams,
     ShowDecisionUsage,
 } from '../attributes';
+import { resolveLayout } from '../helpers';
 
-type Props = ShowDecisionProps & {
+type Props = DecisionTypeComponentProps & {
     name?: boolean;
     description?: boolean;
     usage?: boolean;
@@ -24,8 +27,10 @@ type Props = ShowDecisionProps & {
 const {
     store,
     d,
+    layout,
     value: showValue = true,
     viz: showViz = true,
+    size = 'm',
     options: showOptions,
     name: showName = true,
     description: showDescription = true,
@@ -34,9 +39,29 @@ const {
     params: showParams,
     contexts: showContexts,
     data: showData,
+    ...rest
 } = Astro.props;
 
+function resolveCardLayout(
+    layout: ShowDecisionLayout,
+    isSet: boolean,
+    setLayout: LayoutDynamicProps['layout'],
+) {
+    if (isSet) {
+        if (layout) {
+            return setLayout === 'column' ? 'row' : 'column';
+        }
+        return 'column';
+    }
+    return 'row';
+}
+
 const [, decision] = store.decision({ $name: d });
+
+const isSet = Boolean(decision && isSetDecision(decision));
+const defaultLayout: ShowDecisionLayout = isSet ? ['row', 'column'] : ['column'];
+const [setLayout, itemLayout] = resolveLayout(layout, defaultLayout);
+const cardLayout = resolveCardLayout(layout, isSet, setLayout);
 
 const nameSlot = showName && 'header';
 
@@ -50,18 +75,20 @@ const showMeta = showModel || showParams || showContexts || showData;
 const metaSlot = showMeta && 'meta';
 ---
 
-<DecisionCardLayout>
+<DecisionCardLayout layout={cardLayout}>
     {decision && showName && <Fragment slot={nameSlot}>{decision.name()}</Fragment>}
     {
         showValueOrViz && (
             <Fragment slot={vizSlot}>
                 <ShowDecision
+                    {...rest}
                     store={store}
                     d={d}
+                    layout={[setLayout, itemLayout]}
                     value={showValue}
                     viz={showViz}
                     options={showOptions}
-                    size="m"
+                    size={size}
                 />
             </Fragment>
         )

--- a/packages/libs/designer-shows/src/astro/layouts/cards/DecisionCardLayout.astro
+++ b/packages/libs/designer-shows/src/astro/layouts/cards/DecisionCardLayout.astro
@@ -50,7 +50,7 @@ const { layout = 'row' } = Astro.props;
         border: var(--dd-card-border);
     }
 
-    .dd-decision-card .dd-contents {
+    .dd-contents {
         display: flex;
         flex-direction: column;
         padding-top: var(--dd-card-v-space);
@@ -60,7 +60,7 @@ const { layout = 'row' } = Astro.props;
         border-radius: var(--dd-card-border-radius);
     }
 
-    .dd-decision-card .dd-header {
+    .dd-header {
         padding: 0 var(--dd-card-h-space);
         font-size: var(--dd-heading-size);
         font-weight: var(--dd-heading-weight);
@@ -68,7 +68,7 @@ const { layout = 'row' } = Astro.props;
         color: var(--dd-heading-color);
     }
 
-    .dd-decision-card .dd-main {
+    .dd-main {
         display: flex;
         align-items: start;
         gap: var(--dd-card-h-gutter);
@@ -86,7 +86,7 @@ const { layout = 'row' } = Astro.props;
         gap: var(--dd-card-v-gap);
     }
 
-    .dd-decision-card .dd-meta {
+    .dd-meta {
         display: flex;
         flex-direction: column;
         gap: var(--dd-card-v-gap);

--- a/packages/libs/designer-shows/src/astro/layouts/cards/DecisionCardLayout.astro
+++ b/packages/libs/designer-shows/src/astro/layouts/cards/DecisionCardLayout.astro
@@ -1,11 +1,17 @@
 ---
+type Props = {
+    layout?: 'row' | 'column';
+};
+
 const hasHeader = Astro.slots.has('header');
 const hasMain = Astro.slots.has('viz') || Astro.slots.has('desc') || Astro.slots.has('details');
 const hasContents = hasHeader || hasMain;
 const hasMeta = Astro.slots.has('meta');
+
+const { layout = 'row' } = Astro.props;
 ---
 
-<div class="dd-decision-card">
+<div class:list={['dd-decision-card', `dd-layout-${layout}`]}>
     {
         hasContents && (
             <div class="dd-contents">
@@ -64,11 +70,17 @@ const hasMeta = Astro.slots.has('meta');
 
     .dd-decision-card .dd-main {
         display: flex;
+        align-items: start;
         gap: var(--dd-card-h-gutter);
         padding: 0 var(--dd-card-h-space);
     }
 
-    .dd-decision-card .dd-details {
+    .dd-layout-column .dd-main {
+        flex-direction: column;
+        gap: var(--dd-card-v-gap);
+    }
+
+    .dd-details {
         display: flex;
         flex-direction: column;
         gap: var(--dd-card-v-gap);


### PR DESCRIPTION
Task: #30 

## Add a `layout` prop? to DecisionCard 

Allows controlling how to render color/space sets

Value is passed directly to <ShowDecision> 

Infer card layout from isSetDecision(decision) and `layout` prop.
- if decision is a set/scale and layout was provided => flip the layout
- if decision is a set/scale and layout was not! provided => `column`
- not a set/scale => `row`

<img width="1198" alt="Screenshot 2025-02-06 at 18 30 12" src="https://github.com/user-attachments/assets/cf6292d8-919f-4cb5-8922-23d567cc58be" />
